### PR TITLE
Fix link to pyscbwrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ web-based GUI.
 - R package [rjstat](https://cran.r-project.org/package=rjstat). Read and write data sets in the JSON-stat format. 
 - R package [censusapi](https://cran.r-project.org/package=censusapi) A wrapper for the U.S. Census Bureau APIs that returns data frames of Census data and metadata.
 - R package [nsoApi](https://github.com/bowerth/nsoApi) builds on other packages to access data from official statistics and tries to harmonize the API.
-- Python package [pyscbwrapper](ttps://github.com/kirajcg/pyscbwrapper). Access to the open data API of the Swedish Statistical Institute
+- Python package [pyscbwrapper](https://github.com/kirajcg/pyscbwrapper). Access to the open data API of the Swedish Statistical Institute
 
 ## Contributions
 


### PR DESCRIPTION
there is also https://github.com/rOpenGov/dkstat but still in beta and possibly dormant?