### PR TITLE
add sdcHierarchies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ produced maintained and distributed by the US Census Bureau.
 - R package [sdcTable](https://CRAN.R-project.org/package=sdcTable). Disclosure
   control for tabulated data.
 - R package [easySdcTable](https://CRAN.R-project.org/package=easySdcTable) provides an interface to the package sdcTable.
+- R package [sdcHierarchies](https://CRAN.R-project.org/package=sdcHierarchies) allows to generate, modify and export nested hierarchies.
 - R package [SmallCountRounding](https://CRAN.R-project.org/package=SmallCountRounding) can be used to protect frequency tables by rounding necessary inner cells so that cross-classifications to be published are safe.
 - R package [simPop](https://CRAN.R-project.org/package=simPop). Simulation of synthetic populations from census/survey data considering auxiliary information.
 

--- a/data/software.csv
+++ b/data/software.csv
@@ -45,6 +45,7 @@
 "statistical disclosure control","6.4","sdcMicro","https://CRAN.R-project.org/package=sdcMicro","R",TRUE,TRUE,TRUE
 "statistical disclosure control","6.4","sdcTable","https://CRAN.R-project.org/package=sdcTable","R",TRUE,TRUE,TRUE
 "statistical disclosure control","6.4","easySdcTable","https://CRAN.R-project.org/package=easySdcTable","R",TRUE,TRUE,TRUE
+"statistical disclosure control","6.4","sdcHierarchies","https://CRAN.R-project.org/package=sdcHierarchies","R",TRUE,TRUE,TRUE
 "statistical disclosure control","6.4","SmallCountRounding","https://CRAN.R-project.org/package=SmallCountRounding","R",TRUE,TRUE,TRUE
 "statistical disclosure control","6.4","simPop","https://CRAN.R-project.org/package=simPop","R",TRUE,TRUE,TRUE
 "statistical dissemination","7.2","SDMX Converter","https://webgate.ec.europa.eu/fpfis/mwikis/sdmx/index.php/SDMX_Converter","[SDMX",TRUE,FALSE,FALSE


### PR DESCRIPTION
hi @markvanderloo and @donthebike

my new package [`sdcHierarchies`](https://cran.r-project.org/web/packages/sdcHierarchies/index.html)  that allows to generate nested hierarchies (used for example in [`sdcTable`](https://cran.r-project.org/web/packages/sdcTable/index.html)) is now on CRAN. I'd be happy if you could add it to the awesome list. Thx, Bernhard