### PR TITLE
Add SDMX Connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ web-based GUI.
 - R package [destatiscleanr](https://github.com/cutterkom/destatiscleanr). Clean csv files from [Genesis](https://www-genesis.destatis.de/genesis/online), the database of the Federal Statistical Office of Germany (Destatis) and its regional outlets.
 - R package [cdlTools](https://cran.r-project.org/package=cdlTools). Downloads USDA National Agricultural Statistics Service (NASS) cropscape data for a specified state.
 - Java package [SDMX Connectors](https://github.com/amattioc/SDMX). Browse SDMX data providers, build your queries and get data directly in your favourite tool (R, SAS, Matlab, Stata and Excel). By Banca d'Italia.
+- Node.js package [sdmx-rest](https://www.npmjs.com/package/sdmx-rest). This library allows to easily create and execute SDMX REST queries from a JavaScript client application.
 
 ## Contributions
 


### PR DESCRIPTION
I'd like to suggest adding the SDMX Connectors from Bank of Italy, as well as the sdmx-rest Node.js package. 

The SDMX Connectors allow retrieving data from various providers of SDMX data (ECB, OECD, Eurostat, etc.) using a variety of tools (Matlab, Stata, etc.). 

sdmx-rest allows to easily create and execute SDMX REST queries from a JavaScript client application (disclaimer: I'm the maintainer of this library).