### PR TITLE
List {czso}, R package for Czech statistical open data

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ web-based GUI.
 - R package [csodata](https://cran.r-project.org/package=csodata) Download data from Central Statistics 
   Office (CSO) of Ireland.
 - R package [iriR](https://cran.r-project.org/package=iriR). Client for the European Commission’s Industrial R&D Investment Scoreboard (IRI)
+- R package [czso](https://cran.r-project.org/package=czso). Access open data from the Czech Statistical Office.
 
 ## Contributions
 


### PR DESCRIPTION
This is package is developed outside of the data provider, but it uses the official open data API of the Czech Statistical Office (CZSO). The package's API generally follows the standard principles used in similar R packages for other open data sources, e.g. {eurostat} and {OECD}.﻿