### PR TITLE
Update software.yaml / Add restatis and pystatis

### DIFF
--- a/data/software.yaml
+++ b/data/software.yaml
@@ -981,3 +981,21 @@
   standard:
   access_to:
   - Denmark
+- type: R package
+  name: restatis
+  url: https://cran.r-project.org/package=restatis
+  description: R API Client for the German Federal Statistical Office Database
+  gsbpm_name: Access to official statistics
+  gsbpm_number: '7.4'
+  standard:
+  access_to:
+  - Germany
+- type: Python library
+  name: pystatis
+  url: https://pypi.org/project/pystatis/
+  description: Python wrapper for GENESIS web service interface (API) of the Federal Statistical Office
+  gsbpm_name: Access to official statistics
+  gsbpm_number: '7.4'
+  standard:
+  access_to:
+  - Germany


### PR DESCRIPTION
I have added the R package "restatis" and the Python sister library pystatis to the list. The two are relatively recent packages that have been developed together and provide access to the API of Germany's Federal Office of Statistics.