### PR TITLE
Add SDMX Dashboard Generator Repository to software.yaml

### DIFF
--- a/data/software.yaml
+++ b/data/software.yaml
@@ -626,6 +626,13 @@
     systems, material flow accounts and water accounts. Supports loops. '
   gsbpm_name: Visualisation
   gsbpm_number: '7.2'
+- type: Python
+  name: SDMX Dashboard Generator
+  url: https://github.com/bis-med-it/SDMX-dashboard-generator/
+  description: 'Open-source web application for SDMX data and metadata rendering
+    based on Dash.'
+  gsbpm_name: Visualisation
+  gsbpm_number: '7.2'
 - type: R package
   name: rsdmx
   url: https://cran.r-project.org/package=rsdmx


### PR DESCRIPTION
## Description

This pull request adds the SDMX Dashboard Generator to the `data/software.yaml` file. 

### Changes Made:
- Added the SDMX Dashboard Generator repository information to the `software.yaml` file.
- Included the repository URL, description, and other relevant details.

### Checklist:
- [X] Added SDMX Dashboard Generator repository details to `software.yaml`.
- [X] Ensured correctness of repository URL and description.

## About SDMX Dashboard Generator
The SDMX Dashboard Generator (SDMX-DG) is an open-source [Dash](https://dash.plotly.com/) application that generates dynamic dashboards by pulling data and metadata from SDMX Rest API. It supports the version 2.1 of the standard. It leverages the open-source library SDMXthon to retrieve and parse data and metadata in SDMX. Data and metadata are supported by asynchronous retrieval. A dashboard is composed of several visualizations as defined by the specifications provided in a .yaml file. 
The specifications are interpreted by a ChartGenerator class containing instructions to define the Plotly charts. It has been developed for the [SDMX Hackathon Global Conference 2023](https://www.sdmx2023.org/hackathon).

### Documentation
A quick introduction to the SDMX Dashboard Generator is available at [sdmx.io](https://www.sdmx.io/tools/sdmx-dg/). The full documentation for this app is available at [GitHub Pages](https://bis-med-it.github.io/SDMX-dashboard-generator/).