### PR TITLE
Update software.yaml

### DIFF
--- a/data/software.yaml
+++ b/data/software.yaml
@@ -1012,3 +1012,11 @@
   standard:
   access_to:
   - Germany
+- type: R package
+  name: nonprobsvy
+  url: https://cran.r-project.org/package=nonprobsvy
+  description: Statistical inference with non-probability samples when auxiliary information is available from external sources 
+    such as probability samples or population totals or means. The package implements inverse probability weighting, mass imputation
+    and doubly robust estimators possibly with high-dimensional covariates.
+  gsbpm_name: Estimation and weighting
+  gsbpm_number: 5.6 | 5.7


### PR DESCRIPTION
information about the `nonprobsvy` package recently uploaded to CRAN. The package implements state-of-the-art methods for non-probability samples with focus on variance estimation. Details can be found in: Wu et al. (2020) <[doi:10.1080/01621459.2019.1677241](https://doi.org/10.1080%2F01621459.2019.1677241)>, Kim et al. (2021) <[doi:10.1111/rssa.12696](https://doi.org/10.1111%2Frssa.12696)>, Wu et al. (2023) <https://www150.statcan.gc.ca/n1/pub/12-001-x/2022002/article/00002-eng.htm>, Kim et al. (2021) <https://www150.statcan.gc.ca/n1/pub/12-001-x/2021001/article/00004-eng.htm>, Kim et al. (2020) <[doi:10.1111/rssb.12354](https://doi.org/10.1111%2Frssb.12354)>.