### PR TITLE
Added two R packages: 'nrba' and 'svrep'

### DIFF
--- a/data/software.yaml
+++ b/data/software.yaml
@@ -1029,3 +1029,17 @@
     and doubly robust estimators possibly with high-dimensional covariates.
   gsbpm_name: Estimation and weighting
   gsbpm_number: 5.6 | 5.7
+- type: R package
+  name: svrep
+  url: https://cran.r-project.org/package=svrep
+  description: R package creating and working with survey replicate weights, extending functionality of the 'survey' package in R.
+    Creates replicate weights using bootstrap, generalized bootstrap, generalized replication, and random-group jackknife methods.
+    Facilitates sample-based calibration and nonresponse adjustment methods.
+  gsbpm_name: Estimation and Weighting
+  gsbpm_number: '5.6'
+- type: R package
+  name: nrba
+  url: https://cran.r-project.org/package=nrba
+  description: Facilitates nonresponse bias analysis (NRBA) and nonresponse adjustments for survey data.
+  gsbpm_name: Validate outputs
+  gsbpm_number: '6.2'


### PR DESCRIPTION
This PR adds two R packages to the list, at the bottom of `software.yaml`. The package 'svrep' is already on the CRAN Official Statistics Task View, while the package 'nrba' is not yet on the Task View.

Please let me know if there's anything you'd like me to add or clarify.

Thanks,

Ben