### PR TITLE
Add R package SSBtools

### DIFF
--- a/data/software.yaml
+++ b/data/software.yaml
@@ -456,6 +456,17 @@
   gsbpm_name: Estimation and weighting
   gsbpm_number: 5.6 | 5.7
 - type: R package
+  name: SSBtools
+  url: https://cran.r-project.org/package=SSBtools
+  description:  Includes functionality to compute tabular aggregates according to a hierarchical structure. 
+    For example, using the package's functions 
+    [model_aggregate()](https://statisticsnorway.github.io/ssb-ssbtools/reference/model_aggregate.html), 
+    [tables_by_formulas()](https://statisticsnorway.github.io/ssb-ssbtools/reference/tables_by_formulas.html) and 
+    [quantile_weighted()](https://statisticsnorway.github.io/ssb-ssbtools/reference/quantile_weighted.html). 
+    It also is a dependency package for several packages under "Statistical disclosure control".
+  gsbpm_name: Estimation and weighting
+  gsbpm_number: 5.6 | 5.7
+- type: R package
   name: validate
   url: https://cran.r-project.org/package=validate
   description: Rule management and data validation.


### PR DESCRIPTION
For example, model_aggregate() is used together with quantile_weighted() in this statistic: https://www.ssb.no/en/arbeid-og-lonn/lonn-og-arbeidskraftkostnader/statistikk/lonn